### PR TITLE
Save context for every request

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension Test-WWW-Mechanize-Catalyst-WithContext
 
 {{$NEXT}}
 
+    - add ctx attribute and a new _do_catalyst_request method to save the
+      context after every request.
+
 0.02 2017-08-28T13:30:14Z
 
     - fix bug where using get_context would throw an error about a missing base for the URI if no other request had been made on this $mech
@@ -9,4 +12,3 @@ Revision history for Perl extension Test-WWW-Mechanize-Catalyst-WithContext
 0.01 2017-02-04T14:24:04Z
 
     - first release
-

--- a/t/10_default.t
+++ b/t/10_default.t
@@ -20,7 +20,8 @@ dies_ok { $mech->get_context } 'url is required';
 
 my $old_c;
 {
-    my ( $res, $c ) = $mech->get_context('/');
+    my $res = $mech->get('/');
+    my $c   = $mech->ctx;
     isa_ok $res, 'HTTP::Response', '$res';
     is $res->code, 200, '... and request was successful';
 
@@ -40,7 +41,8 @@ $mech->get_ok('/set_session/hello/world');
 
 is $old_c->session->{hello}, undef, 'old context does not know about session after new request';
 {
-    my ( $res, $c ) = $mech->get_context('/');
+    my $res = $mech->post('/');
+    my $c   = $mech->ctx;
     is $c->session->{hello}, 'world', '... but new context does';
     is $c->stash->{foo}, '2', 'new context has a new stash';
     isnt "$c", "$old_c", 'old context and new context are different refs';


### PR DESCRIPTION
This change adds a ctx attribute that is updated after every
request.

This allows one to test the Catalyst context after every request,
for every method (e.g. POST).

The get_context method is no longer necessary.